### PR TITLE
Mark unused config_entry parameter with underscore prefix

### DIFF
--- a/homeassistant/components/demo/air_quality.py
+++ b/homeassistant/components/demo/air_quality.py
@@ -10,7 +10,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    _config_entry: ConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Demo config entry."""


### PR DESCRIPTION
**Shyam Naga Suraj Dodla - Group 10**

# Title: Remove unused function parameter code smell in demo air_quality component

## Description:

This pull request addresses a maintainability code smell identified in the demo air quality component where the
config_entry parameter in the async_setup_entry function was unused.

### Why this issue is relevant and important:

Unused function parameters represent dead code that negatively impacts code maintainability in several ways:
• They create confusion for developers who may wonder if the parameter should be used
• They increase cognitive load when reading and understanding the code
• They can mislead future developers into thinking the parameter serves a purpose
• They violate the principle of least surprise and clean code practices
• In large codebases like Home Assistant, such issues accumulate and degrade overall code quality

#### How the issue was addressed:

Rather than completely removing the parameter (which would break Home Assistant's framework requirements), I applied the
Python convention of prefixing unused parameters with an underscore. This solution:
• Clearly communicates to developers that the parameter is intentionally unused
• Maintains compatibility with Home Assistant's framework expectations
• Follows established Python conventions for handling required but unused parameters
• Passes all linting and testing requirements
• Preserves the function signature required by the platform setup system

##### Why this solution solves the problem:

The underscore prefix (_config_entry) is a widely recognized Python convention that explicitly signals intentional non-
use of a parameter. This approach:
• Eliminates the ambiguity about whether the parameter should be used
• Maintains framework compatibility while addressing the code smell
• Follows Python best practices for handling required but unused parameters
• Makes the code more maintainable by clearly documenting developer intent
• Prevents future developers from accidentally trying to use or remove the parameter

***The solution successfully passes all automated checks including ruff, pylint, and the existing test suite, confirming it
maintains code quality while addressing the identified issue.***